### PR TITLE
Host malloc

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -3,8 +3,8 @@
 maker=$1
 device=$2
 
-mydir=`dirname $0`
-source $mydir/setup_env.sh
+mydir=$(dirname $0)
+source ${mydir}/setup_env.sh
 
 section "======================================== Build"
 make -j8
@@ -14,13 +14,13 @@ make -j8 install
 ls -R ${top}/install
 
 section "======================================== Verify build"
-ldd test/tester
+ldd_result=$(ldd test/tester)
+echo "${ldd_result}"
 
 # Verify that tester linked with cublas or rocblas as intended.
 if [ "${device}" = "gpu_nvidia" ]; then
-    ldd test/tester | grep cublas || exit 1
+    echo "${ldd_result}" | grep cublas || exit 1
 fi
 if [ "${device}" = "gpu_amd" ]; then
-    ldd test/tester | grep rocblas || exit 1
+    echo "${ldd_result}" | grep rocblas || exit 1
 fi
-

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe 
+#!/bin/bash -xe
 
 maker=$1
 device=$2
@@ -14,8 +14,9 @@ make -j8 install
 ls -R ${top}/install
 
 section "======================================== Verify build"
-# Verify that tester linked with cublas or rocblas as intended.
 ldd test/tester
+
+# Verify that tester linked with cublas or rocblas as intended.
 if [ "${device}" = "gpu_nvidia" ]; then
     ldd test/tester | grep cublas || exit 1
 fi

--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -8,8 +8,8 @@ if [ "${maker}" = "cmake" ]; then
     mkdir -p build
 fi
 
-mydir=`dirname $0`
-source $mydir/setup_env.sh
+mydir=$(dirname $0)
+source ${mydir}/setup_env.sh
 
 section "======================================== Verify dependencies"
 quiet module list

--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -1,15 +1,25 @@
-#!/bin/bash -xe 
+#!/bin/bash -xe
 
 maker=$1
 device=$2
 
-if [ "$maker" = "cmake" ]; then
-   rm -rf build
-   mkdir -p build
+if [ "${maker}" = "cmake" ]; then
+    rm -rf build
+    mkdir -p build
 fi
 
 mydir=`dirname $0`
 source $mydir/setup_env.sh
+
+section "======================================== Verify dependencies"
+quiet module list
+quiet which g++
+quiet g++ --version
+
+echo "MKLROOT=${MKLROOT}"
+
+section "======================================== Environment"
+env
 
 section "======================================== Setup build"
 export color=no

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
-jobs:          
+jobs:
   icl_blaspp:
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,3 @@ jobs:
         run: .github/workflows/build.sh ${{matrix.maker}} ${{matrix.device}}
       - name: Test
         run: .github/workflows/test.sh ${{matrix.maker}} ${{matrix.device}}
-

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -28,7 +28,7 @@ alias section='{ save_flags="$-"; set +x; } 2> /dev/null; print_section'
 quiet source /etc/profile
 
 hostname && pwd
-export top=`pwd`
+export top=$(pwd)
 
 shopt -s expand_aliases
 

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -17,7 +17,7 @@ quiet() {
 print_section() {
     builtin echo "$*"
     date
-    case "$save_flags" in
+    case "${save_flags}" in
         (*x*)  set -x
     esac
 }

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
 
-shopt -s expand_aliases
-
-set +x
-
-source /etc/profile
-
-top=`pwd`
+#-------------------------------------------------------------------------------
+# Functions
 
 # Suppress echo (-x) output of commands executed with `quiet`.
+# Useful for sourcing files, loading modules, spack, etc.
+# set +x, set -x are not echo'd.
 quiet() {
     { set +x; } 2> /dev/null;
     $@;
     set -x
 }
 
+# `section` is like `echo`, but suppresses output of the command itself.
+# https://superuser.com/a/1141026
 print_section() {
     builtin echo "$*"
     date
@@ -24,8 +23,19 @@ print_section() {
 }
 alias section='{ save_flags="$-"; set +x; } 2> /dev/null; print_section'
 
-module load gcc@7.3.0
-module load intel-mkl
+
+#-------------------------------------------------------------------------------
+quiet source /etc/profile
+
+hostname && pwd
+export top=`pwd`
+
+shopt -s expand_aliases
+
+
+section "======================================== Load compiler"
+quiet module load gcc@7.3.0
+quiet module load intel-mkl
 
 if [ "${device}" = "gpu_nvidia" ]; then
     section "======================================== Load CUDA"
@@ -49,23 +59,8 @@ fi
 
 if [ "${maker}" = "cmake" ]; then
     section "======================================== Load cmake"
-    module load cmake
+    quiet module load cmake
     which cmake
     cmake --version
     cd build
 fi
-
-
-section "======================================== Verify dependencies"
-module list
-
-which g++
-g++ --version
-
-echo "MKLROOT=${MKLROOT}"
-
-section "======================================== Environment"
-env
-
-set -x
-

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -3,8 +3,8 @@
 maker=$1
 device=$2
 
-mydir=`dirname $0`
-source $mydir/setup_env.sh
+mydir=$(dirname $0)
+source ${mydir}/setup_env.sh
 
 section "======================================== Tests"
 cd test

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe 
+#!/bin/bash -xe
 
 maker=$1
 device=$2
@@ -25,7 +25,7 @@ if [ "${maker}" = "make" ]; then
 fi
 if [ "${maker}" = "cmake" ]; then
     rm -rf build && mkdir build && cd build
-    cmake -DCMAKE_PREFIX_PATH=${top}/install/lib64/blaspp ..
+    cmake "-DCMAKE_PREFIX_PATH=${top}/install/lib64/blaspp" ..
 fi
 
 make

--- a/config/rocblas.cc
+++ b/config/rocblas.cc
@@ -8,7 +8,13 @@
 #endif
 
 #include <hip/hip_runtime.h>
-#include <rocblas.h>
+
+// Headers moved in ROCm 5.2
+#if HIP_VERSION >= 50200000
+    #include <rocblas/rocblas.h>
+#else
+    #include <rocblas.h>
+#endif
 
 #include <stdexcept>
 #include <cassert>

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -21,7 +21,13 @@
     #endif
 
     #include <hip/hip_runtime.h>
-    #include <rocblas.h>
+
+    // Headers moved in ROCm 5.2
+    #if HIP_VERSION >= 50200000
+        #include <rocblas/rocblas.h>
+    #else
+        #include <rocblas.h>
+    #endif
 
     // If we defined __HIP_PLATFORM_HCC__, undef it.
     #ifdef BLAS_HIP_PLATFORM_HCC

--- a/include/blas/rotg.hh
+++ b/include/blas/rotg.hh
@@ -34,7 +34,7 @@ namespace blas {
 ///     Cosine of rotation; real.
 ///
 /// @param[out] s
-///     Sine of rotation;   real.
+///     Sine of rotation; real.
 ///
 /// __Further details__
 ///

--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -117,7 +117,10 @@ void enumerate_devices(std::vector<cl::sycl::device> &devices)
 #endif
 
 // -----------------------------------------------------------------------------
-/// free a device pointer
+/// @deprecated: use device_free( ptr, queue ).
+/// Free a device memory space on the current device,
+/// allocated with device_malloc.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
 void device_free( void* ptr )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -138,7 +141,8 @@ void device_free( void* ptr )
 }
 
 // -----------------------------------------------------------------------------
-/// free a device pointer for a given device
+/// Free a device memory space, allocated with device_malloc,
+/// on the queue's device.
 void device_free( void* ptr, blas::Queue &queue )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -152,14 +156,16 @@ void device_free( void* ptr, blas::Queue &queue )
             hipFree( ptr ) );
 
     #elif defined(BLAS_HAVE_ONEMKL)
-       blas_dev_call(
-           sycl::free( ptr, queue.stream() ) );
+        blas_dev_call(
+            sycl::free( ptr, queue.stream() ) );
     #endif
 }
 
 // -----------------------------------------------------------------------------
-/// free a pinned memory space
-void device_free_pinned( void* ptr )
+/// @deprecated: use host_free_pinned( ptr, queue ).
+/// Free a pinned host memory space, allocated with host_malloc_pinned.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
+void host_free_pinned( void* ptr )
 {
     #ifdef BLAS_HAVE_CUBLAS
         blas_dev_call(
@@ -178,8 +184,8 @@ void device_free_pinned( void* ptr )
 }
 
 // -----------------------------------------------------------------------------
-/// free a pinned memory space
-void device_free_pinned( void* ptr,  blas::Queue &queue )
+/// Free a pinned host memory space, allocated with host_malloc_pinned.
+void host_free_pinned( void* ptr, blas::Queue &queue )
 {
     #ifdef BLAS_HAVE_CUBLAS
         blas_dev_call(

--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -10,7 +10,9 @@
 namespace blas {
 
 // -----------------------------------------------------------------------------
-// set device
+/// @deprecated
+/// Set current GPU device.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
 void set_device( blas::Device device )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -30,7 +32,9 @@ void set_device( blas::Device device )
 }
 
 // -----------------------------------------------------------------------------
-// get current device
+/// @deprecated
+/// Get current GPU device.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
 void get_device( blas::Device *device )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -54,7 +58,7 @@ void get_device( blas::Device *device )
 }
 
 // -----------------------------------------------------------------------------
-// @return number of GPU devices
+/// @return number of GPU devices.
 device_blas_int get_device_count()
 {
     device_blas_int dev_count = 0;
@@ -70,13 +74,13 @@ device_blas_int get_device_count()
             blas_dev_call( err );
 
     #elif defined(BLAS_HAVE_ONEMKL)
-    auto platforms = sycl::platform::get_platforms();
-    for (auto &platform : platforms) {
-        auto devices = platform.get_devices();
-        for (auto &device : devices ) {
-            dev_count += device.is_gpu();
+        auto platforms = sycl::platform::get_platforms();
+        for (auto &platform : platforms) {
+            auto devices = platform.get_devices();
+            for (auto &device : devices ) {
+                dev_count += device.is_gpu();
+            }
         }
-    }
 
     #else
         // return dev_count = 0
@@ -86,13 +90,13 @@ device_blas_int get_device_count()
 }
 
 // -----------------------------------------------------------------------------
-// @return a vector of sycl gpu devices
+/// @return vector of SYCL GPU devices.
 #ifdef BLAS_HAVE_ONEMKL
 void enumerate_devices(std::vector<cl::sycl::device> &devices)
 {
     device_blas_int dev_count = get_device_count();
 
-    if(devices.size() != (size_t)dev_count) {
+    if (devices.size() != (size_t)dev_count) {
         devices.clear();
         devices.reserve( dev_count );
     }

--- a/test/test_memcpy.cc
+++ b/test/test_memcpy.cc
@@ -88,10 +88,10 @@ void test_memcpy_work( Params& params, bool run )
     int64_t inc = std::max( inc_ac, inc_bd );
     int64_t extra = 2;
     int64_t size = inc*(n + extra);
-    T* a_host = blas::device_malloc_pinned<T>( size, queue );
-    T* b_host = blas::device_malloc_pinned<T>( size, queue );
-    T* c_host = blas::device_malloc_pinned<T>( size, queue );
-    T* d_host = blas::device_malloc_pinned<T>( size, queue );
+    T* a_host = blas::host_malloc_pinned<T>( size, queue );
+    T* b_host = blas::host_malloc_pinned<T>( size, queue );
+    T* c_host = blas::host_malloc_pinned<T>( size, queue );
+    T* d_host = blas::host_malloc_pinned<T>( size, queue );
 
     // device specifics
     T* b_dev = blas::device_malloc<T>( size, queue );
@@ -259,10 +259,10 @@ void test_memcpy_work( Params& params, bool run )
     if (verbose >= 1)
         printf( "cleanup\n" );
 
-    blas::device_free_pinned( a_host, queue );
-    blas::device_free_pinned( b_host, queue );
-    blas::device_free_pinned( c_host, queue );
-    blas::device_free_pinned( d_host, queue );
+    blas::host_free_pinned( a_host, queue );
+    blas::host_free_pinned( b_host, queue );
+    blas::host_free_pinned( c_host, queue );
+    blas::host_free_pinned( d_host, queue );
     blas::device_free( b_dev, queue );
     blas::device_free( c_dev, queue );
 }

--- a/test/test_memcpy_2d.cc
+++ b/test/test_memcpy_2d.cc
@@ -80,10 +80,10 @@ void test_memcpy_2d_work( Params& params, bool run )
     int64_t ld = roundup( m, align );
     int64_t extra = 2;
     int64_t size = ld*(n + extra);
-    T* a_host = blas::device_malloc_pinned<T>( size, queue );
-    T* b_host = blas::device_malloc_pinned<T>( size, queue );
-    T* c_host = blas::device_malloc_pinned<T>( size, queue );
-    T* d_host = blas::device_malloc_pinned<T>( size, queue );
+    T* a_host = blas::host_malloc_pinned<T>( size, queue );
+    T* b_host = blas::host_malloc_pinned<T>( size, queue );
+    T* c_host = blas::host_malloc_pinned<T>( size, queue );
+    T* d_host = blas::host_malloc_pinned<T>( size, queue );
 
     // device specifics
     T* b_dev = blas::device_malloc<T>( size, queue );
@@ -234,10 +234,10 @@ void test_memcpy_2d_work( Params& params, bool run )
     params.error() = error;
     params.okay() = (error == 0);  // copy must be exact
 
-    blas::device_free_pinned( a_host, queue );
-    blas::device_free_pinned( b_host, queue );
-    blas::device_free_pinned( c_host, queue );
-    blas::device_free_pinned( d_host, queue );
+    blas::host_free_pinned( a_host, queue );
+    blas::host_free_pinned( b_host, queue );
+    blas::host_free_pinned( c_host, queue );
+    blas::host_free_pinned( d_host, queue );
     blas::device_free( b_dev, queue );
     blas::device_free( c_dev, queue );
 }


### PR DESCRIPTION
* Rename `device_malloc_pinned` to `host_malloc_pinned`, since it is host memory.
* Deprecate old routines in Doxygen. We will do C++ deprecation once SLATE is updated.
* Update docs and clean code a bit.